### PR TITLE
Fix duplicate filtering in dyad analysis

### DIFF
--- a/apparent.R
+++ b/apparent.R
@@ -437,6 +437,8 @@ apparent = function (InputFile, MaxIdent=0.10, alpha=0.01, nloci=300, self=TRUE,
           } else {
             Out3a <- rbind (Out3a,Out3[j,])
           }
+        }
+        else {
           Out3a <- rbind (Out3a,Out3[i,])
         }
       }


### PR DESCRIPTION
Hi,

I believe this PR fixes the issue here: https://github.com/halelab/apparent/issues/2

Just had to add an `else` condition so that we catch cases where there is not a duplicate pairing in the dyad analysis output.